### PR TITLE
[FEAT] 숫자 야구 게임 기본 기능 구현

### DIFF
--- a/src/main/kotlin/baseball/App.kt
+++ b/src/main/kotlin/baseball/App.kt
@@ -1,0 +1,6 @@
+package baseball
+
+fun main() {
+    while (play() == 1) {
+    }
+}

--- a/src/main/kotlin/baseball/Game.kt
+++ b/src/main/kotlin/baseball/Game.kt
@@ -1,0 +1,19 @@
+package baseball
+
+/*
+    * 게임을 실행합니다
+    * 3스트라이크가 될 때까지 반복합니다
+    * 3스트라이크가 되면 게임 종료 메시지를 출력하고 재시작 여부를 입력받습니다
+    * 재시작 여부에 따라 1 또는 2를 반환합니다
+ */
+fun play(): Int {
+    val answer = generateRandom()
+    while (true) {
+        var guess: Int = getValidInputNumber()
+        val (balls, strikes) = getResult(answer, guess)
+        println(resultMessage(balls, strikes))
+        if (strikes == 3) break
+    }
+    printGameEndMessage()
+    return getRestartInput()
+}

--- a/src/main/kotlin/baseball/GameIO.kt
+++ b/src/main/kotlin/baseball/GameIO.kt
@@ -6,7 +6,7 @@ package baseball
     * 3자리가 아닌 값은 IllegalArgumentException을 던집니다
  */
 fun getValidInputNumber(): Int {
-    print(GameMessage.INPUT_NUMBER_MESSAGE)
+    print(GameMessage.INPUT_NUMBER_MESSAGE.message)
 
     // 올바른 형식 체크
     val guessNumber = readln().toIntOrNull() ?: throw NumberFormatException(GameError.NOT_NUMBER.message)

--- a/src/main/kotlin/baseball/GameIO.kt
+++ b/src/main/kotlin/baseball/GameIO.kt
@@ -1,0 +1,38 @@
+package baseball
+
+/*
+    * 유저의 입력값을 받습니다
+    * 숫자가 아닌 값은 NumberFormatException을 던집니다
+    * 3자리가 아닌 값은 IllegalArgumentException을 던집니다
+ */
+fun getValidInputNumber(): Int {
+    print(GameMessage.INPUT_NUMBER_MESSAGE)
+
+    // 올바른 형식 체크
+    val guessNumber = readln().toIntOrNull() ?: throw NumberFormatException(GameError.NOT_NUMBER.message)
+
+    // 3자리 체크
+    if (guessNumber !in 111..999) throw IllegalArgumentException(GameError.NOT_THREE_DIGITS.message)
+
+    return guessNumber
+}
+
+
+
+/*
+    * 게임 종료 메시지를 출력합니다.
+ */
+fun printGameEndMessage() {
+    println(GameMessage.THREE_STRIKE_MESSAGE.message)
+    println(GameMessage.RESTART_OR_QUIT_MESSAGE.message)
+}
+
+/*
+    * 게임 재시작 여부를 입력받습니다.
+    * 1 또는 2가 아닌 경우 IllegalArgumentException을 던집니다.
+ */
+fun getRestartInput(): Int {
+    val input = readln().toIntOrNull() ?: throw IllegalArgumentException(GameError.INVALID_RESTART_INPUT.message)
+    if (input != 1 && input != 2) throw IllegalArgumentException(GameError.INVALID_RESTART_INPUT.message)
+    return input
+}

--- a/src/main/kotlin/baseball/GameService.kt
+++ b/src/main/kotlin/baseball/GameService.kt
@@ -1,0 +1,41 @@
+package baseball
+
+/*
+    * 중복되지 않는 1..9으로 구성된 3자리 수를 생성합니다
+ */
+fun generateRandom() : Int  {
+    val digits = (1..9).shuffled().take(3)
+    return digits.joinToString("").toInt()
+}
+
+/*
+    * 랜덤값과 유저의 입력값을 비교해서 볼, 스트라이크의 갯수를 반환합니다
+ */
+fun getResult(randomNumber: Int, guessNumber: Int): Pair<Int, Int> {
+    if (randomNumber == guessNumber) return Pair(0, 3)
+
+    val randomNumberStr = randomNumber.toString()
+    val guessNumberStr = guessNumber.toString()
+
+    var balls = 0
+    var strikes = 0
+
+    for (i in 0..2) {
+        when {
+            guessNumberStr[i] == randomNumberStr[i] -> strikes++
+            guessNumberStr[i] in randomNumberStr -> balls++
+        }
+    }
+
+    return balls to strikes
+}
+
+
+/*
+    * 결과값에 따라 메세지를 출력합니다
+ */
+fun resultMessage(balls: Int, strikes: Int): String =
+    buildList {
+        if (balls > 0) add("${balls}볼")
+        if (strikes > 0) add("${strikes}스트라이크")
+    }.joinToString(" ").ifBlank { "낫싱" }

--- a/src/main/kotlin/baseball/Message.kt
+++ b/src/main/kotlin/baseball/Message.kt
@@ -1,0 +1,20 @@
+package baseball
+
+
+/*
+    * 게임 일반 메시지를 관리하는 Enum 클래스
+ */
+enum class GameMessage(val message: String) {
+    INPUT_NUMBER_MESSAGE("숫자를 입력해주세요 :"),
+    THREE_STRIKE_MESSAGE("3개의 숫자를 모두 맞히셨습니다! 게임 종료"),
+    RESTART_OR_QUIT_MESSAGE("게임을 새로 시작하려면 1, 종료하려면 2를 입력하세요.");
+}
+
+/*
+    * 게임 오류 메시지를 관리하는 Enum 클래스
+ */
+enum class GameError(val message: String) {
+    NOT_NUMBER("숫자가 아닙니다"),
+    NOT_THREE_DIGITS("3자리 숫자가 아닙니다"),
+    INVALID_RESTART_INPUT("1 또는 2를 입력해주세요");
+}

--- a/src/test/kotlin/baseball/GetResultTest.kt
+++ b/src/test/kotlin/baseball/GetResultTest.kt
@@ -1,0 +1,65 @@
+package baseball
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.Description
+
+class GetResultTest {
+
+    @Nested
+    inner class GenerateRandom {
+        @Test
+        fun `generateRandom은 항상 3자리 숫자를 생성하고 중복이 없어야 한다`() {
+            repeat(100) { // 여러 번 실행해서 랜덤성 확인
+                val num = generateRandom()
+                val str = num.toString()
+
+                assertEquals(3, str.length, "반드시 3자리여야 한다")
+                assertEquals(3, str.toSet().size, "중복된 숫자가 없어야 한다")
+
+                // 1..9 범위 안인지 확인
+                assertTrue(str.all { it in '1'..'9' }, "모든 숫자는 1~9 사이여야 한다")
+            }
+        }
+    }
+
+
+    @Nested
+    inner class GetResult {
+        @Test
+        fun `3스트라이크 경우`() {
+            val (balls, strikes) = getResult(123, 123)
+            assertEquals(0, balls)
+            assertEquals(3, strikes)
+        }
+
+        @Test
+        fun `3볼 경우`() {
+            val (balls, strikes) = getResult(123, 312)
+            assertEquals(3, balls)   // 숫자는 같지만 자리 다름
+            assertEquals(0, strikes)
+        }
+
+        @Test
+        fun `낫싱 경우`() {
+            val (balls, strikes) = getResult(123, 456)
+            assertEquals(0, balls)
+            assertEquals(0, strikes)
+        }
+    }
+
+
+    @Nested
+    inner class ResultMessage {
+        @Test
+        fun `낫싱을 반환`() {
+            assertEquals("낫싱", resultMessage(0, 0))
+        }
+
+        @Test
+        fun `볼과 스트라이크 모두 출력`() {
+            assertEquals("1볼 2스트라이크", resultMessage(1, 2))
+        }
+    }
+}


### PR DESCRIPTION
## 요구사항
[우테캠 Baseball-precourse](https://github.com/woowacourse/java-baseball-precourse)

## 📌 작업 개요
- 숫자 야구 게임의 기본 기능을 구현했습니다.  
- 입력값 검증, 게임 로직, 메시지 관리 등을 모듈별로 분리했습니다.  

## ✨ 주요 개발 사항
- `App.kt` : 게임 실행 entry point (`main`) 추가
- `Game.kt` : 게임 진행 흐름(`play`) 구현
- `GameService.kt` : 랜덤 숫자 생성(`generateRandom`), 결과 계산(`getResult`), 메시지 포맷팅(`resultMessage`)
- `GameIO.kt` : 사용자 입력/출력 담당 (`getValidInputNumber`, `getRestartInput`, `printGameEndMessage`)
- `Message.kt` : 게임 메시지와 에러 메시지를 Enum 클래스로 관리
- 테스트 코드 : `GetResultTest` 등 유닛 테스트 추가

## 주요 스크린샷
### 게임 실행
<img width="325" height="695" alt="image" src="https://github.com/user-attachments/assets/5147b6d6-211a-42b6-9775-4479234c31cd" />

### 테스트 결과
<img width="349" height="127" alt="image" src="https://github.com/user-attachments/assets/2b5924cf-5e01-4a4f-a23a-ca8455c48070" />
